### PR TITLE
feat: expand repository and pull request tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# ℹ️ DISCUSSION: [Microsoft launched an official ADO MCP Server! 🎉🎉🎉](https://github.com/Tiberriver256/mcp-server-azure-devops/discussions/237)
-
 # Azure DevOps MCP Server
 
 A Model Context Protocol (MCP) server implementation for Azure DevOps, allowing AI assistants to interact with Azure DevOps APIs through a standardized protocol.
@@ -49,6 +47,12 @@ The server uses a feature-based architecture where each feature area (like work-
 
 ### Running with NPX
 
+After building the project with `npm run build`, you can run the server directly with:
+
+```bash
+npx @hmaldonadovilla/mcp-server-azure-devops
+```
+
 ### Usage with Claude Desktop/Cursor AI
 
 To integrate with Claude Desktop or Cursor AI, add one of the following configurations to your configuration file.
@@ -62,7 +66,7 @@ Be sure you are logged in to Azure CLI with `az login` then add the following:
   "mcpServers": {
     "azureDevOps": {
       "command": "npx",
-      "args": ["-y", "@tiberriver256/mcp-server-azure-devops"],
+      "args": ["-y", "@hmaldonadovilla/mcp-server-azure-devops"],
       "env": {
         "AZURE_DEVOPS_ORG_URL": "https://dev.azure.com/your-organization",
         "AZURE_DEVOPS_AUTH_METHOD": "azure-identity",
@@ -80,7 +84,7 @@ Be sure you are logged in to Azure CLI with `az login` then add the following:
   "mcpServers": {
     "azureDevOps": {
       "command": "npx",
-      "args": ["-y", "@tiberriver256/mcp-server-azure-devops"],
+      "args": ["-y", "@hmaldonadovilla/mcp-server-azure-devops"],
       "env": {
         "AZURE_DEVOPS_ORG_URL": "https://dev.azure.com/your-organization",
         "AZURE_DEVOPS_AUTH_METHOD": "pat",
@@ -163,6 +167,9 @@ The Azure DevOps MCP server provides a variety of tools for interacting with Azu
 - `get_repository`: Get details of a specific repository
 - `get_repository_details`: Get detailed information about a repository including statistics and refs
 - `get_file_content`: Get content of a file or directory from a repository
+- `get_repository_tree`: List a repository's file tree from any path and depth
+- `create_branch`: Create a new branch from an existing one
+- `create_commit`: Commit multiple file changes to a branch
 
 ### Work Item Tools
 
@@ -196,6 +203,7 @@ The Azure DevOps MCP server provides a variety of tools for interacting with Azu
 - [`add_pull_request_comment`](docs/tools/pull-requests.md#add_pull_request_comment) - Add a comment to a pull request
 - [`get_pull_request_comments`](docs/tools/pull-requests.md#get_pull_request_comments) - Get comments from a pull request
 - [`update_pull_request`](docs/tools/pull-requests.md#update_pull_request) - Update an existing pull request (title, description, status, draft state, reviewers, work items)
+- [`get_pull_request_changes`](docs/tools/pull-requests.md#get_pull_request_changes) - List changes in a pull request and policy evaluation status
 
 For comprehensive documentation on all tools, see the [Tools Documentation](docs/tools/).
 
@@ -205,7 +213,7 @@ Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for con
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=tiberriver256/mcp-server-azure-devops&type=Date)](https://www.star-history.com/#tiberriver256/mcp-server-azure-devops&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=hmaldonadovilla/mcp-server-azure-devops&type=Date)](https://www.star-history.com/#hmaldonadovilla/mcp-server-azure-devops&Date)
 
 ## License
 

--- a/docs/azure-identity-authentication.md
+++ b/docs/azure-identity-authentication.md
@@ -63,7 +63,7 @@ Add the following to your configuration file:
   "mcpServers": {
     "azureDevOps": {
       "command": "npx",
-      "args": ["-y", "@tiberriver256/mcp-server-azure-devops"],
+      "args": ["-y", "@hmaldonadovilla/mcp-server-azure-devops"],
       "env": {
         "AZURE_DEVOPS_ORG_URL": "https://dev.azure.com/your-organization",
         "AZURE_DEVOPS_AUTH_METHOD": "azure-identity",

--- a/docs/tools/pull-requests.md
+++ b/docs/tools/pull-requests.md
@@ -982,3 +982,45 @@ The `update_pull_request` tool:
 9. Handles errors and provides meaningful error messages
 
 This implementation provides a comprehensive way to update pull requests in Azure DevOps repositories, supporting all common update scenarios.
+
+## get_pull_request_changes
+
+Retrieves the list of files changed in a pull request along with the latest policy evaluation status.
+
+### Parameters
+
+```json
+{
+  "projectId": "MyProject",
+  "repositoryId": "MyRepo",
+  "pullRequestId": 42
+}
+```
+
+### Response
+
+Returns the changed files for the latest iteration and the status of any policy evaluations. Each file entry includes a unified diff patch showing the exact changes.
+
+Example response:
+
+```json
+{
+  "changes": {
+    "changeEntries": [
+      {
+        "item": { "path": "/src/file.ts" },
+        "changeType": 2
+      }
+    ]
+  },
+  "evaluations": [
+    { "id": "1", "status": "approved" }
+  ],
+  "files": [
+    {
+      "path": "/src/file.ts",
+      "patch": "Index: /src/file.ts\n===================================================================\n--- /src/file.ts\n+++ /src/file.ts\n@@ -1 +1 @@\n-old line\n+new line\n"
+    }
+  ]
+}
+```

--- a/docs/tools/repositories.md
+++ b/docs/tools/repositories.md
@@ -521,3 +521,68 @@ console.log(result);
 - `get_repository_details`: Gets detailed info about a single repository
 - `get_repository_tree`: Explores structure within a single repository (more detailed)
 - `get_file_content`: Gets content of a specific file
+- `get_repository_tree`: Explore the tree for a single repository
+- `create_branch`: Create a branch from an existing one
+- `create_commit`: Apply file additions, updates, or deletions in a single commit
+
+## get_repository_tree
+
+Lists files and folders from any point in a repository. You can specify a repository name or path to start from and limit how deep the tree goes.
+
+### Parameters
+
+```json
+{
+  "projectId": "MyProject",
+  "repositoryId": "MyRepo",
+  "path": "src/utils",        // Optional path to start from
+  "depth": 2                   // Optional maximum depth
+}
+```
+
+### Response
+
+Returns a formatted tree showing directories and files starting from the requested location.
+
+## create_branch
+
+Creates a new branch from an existing branch's latest commit.
+
+### Parameters
+
+```json
+{
+  "projectId": "MyProject",
+  "repositoryId": "MyRepo",
+  "sourceBranch": "main",
+  "newBranch": "feature-branch"
+}
+```
+
+### Response
+
+Returns the newly created branch reference.
+
+## create_commit
+
+Commits multiple file changes to a branch, supporting additions, modifications, and deletions.
+
+### Parameters
+
+```json
+{
+  "projectId": "MyProject",
+  "repositoryId": "MyRepo",
+  "branch": "feature-branch",
+  "changes": [
+    { "path": "src/new.ts", "newContent": "console.log('hi')" },
+    { "path": "README.md", "originalContent": "old", "newContent": "new" },
+    { "path": "old.txt", "delete": true }
+  ],
+  "commitMessage": "feat: demo commit"
+}
+```
+
+### Response
+
+Returns the commit ID after applying the changes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@tiberriver256/mcp-server-azure-devops",
+  "name": "@hmaldonadovilla/mcp-server-azure-devops",
   "version": "0.1.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@tiberriver256/mcp-server-azure-devops",
+      "name": "@hmaldonadovilla/mcp-server-azure-devops",
       "version": "0.1.42",
       "license": "MIT",
       "dependencies": {
@@ -13,6 +13,7 @@
         "@modelcontextprotocol/sdk": "^1.6.0",
         "axios": "^1.8.3",
         "azure-devops-node-api": "^13.0.0",
+        "diff": "^5.2.0",
         "dotenv": "^16.3.1",
         "minimatch": "^10.0.1",
         "zod": "^3.24.2",
@@ -24,6 +25,7 @@
       "devDependencies": {
         "@commitlint/cli": "^19.8.0",
         "@commitlint/config-conventional": "^19.8.0",
+        "@types/diff": "^5.2.3",
         "@types/jest": "^29.5.0",
         "@types/node": "^20.0.0",
         "@typescript-eslint/eslint-plugin": "^8.27.0",
@@ -1952,6 +1954,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/diff": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.2.3.tgz",
+      "integrity": "sha512-K0Oqlrq3kQMaO2RhfrNQX5trmt+XLyom88zS0u84nnIcLvFnRUMRRHmrGny5GSM+kNO9IZLARsdQHDzkhAgmrQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -3745,10 +3754,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -9093,6 +9101,16 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/tsconfig": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tiberriver256/mcp-server-azure-devops",
+  "name": "@hmaldonadovilla/mcp-server-azure-devops",
   "version": "0.1.42",
   "description": "Azure DevOps reference server for the Model Context Protocol (MCP)",
   "main": "dist/index.js",
@@ -88,6 +88,7 @@
     "@modelcontextprotocol/sdk": "^1.6.0",
     "axios": "^1.8.3",
     "azure-devops-node-api": "^13.0.0",
+    "diff": "^5.2.0",
     "dotenv": "^16.3.1",
     "minimatch": "^10.0.1",
     "zod": "^3.24.2",
@@ -96,6 +97,7 @@
   "devDependencies": {
     "@commitlint/cli": "^19.8.0",
     "@commitlint/config-conventional": "^19.8.0",
+    "@types/diff": "^5.2.3",
     "@types/jest": "^29.5.0",
     "@types/node": "^20.0.0",
     "@typescript-eslint/eslint-plugin": "^8.27.0",

--- a/shrimp-rules.md
+++ b/shrimp-rules.md
@@ -5,7 +5,7 @@
 ## 1. Project Overview
 
 ### Purpose
-- This project, `@tiberriver256/mcp-server-azure-devops`, is an MCP (Model Context Protocol) server.
+- This project, `@hmaldonadovilla/mcp-server-azure-devops`, is an MCP (Model Context Protocol) server.
 - Its primary function is to provide tools for interacting with Azure DevOps services.
 
 ### Technology Stack

--- a/src/features/pull-requests/get-pull-request-changes/feature.spec.unit.ts
+++ b/src/features/pull-requests/get-pull-request-changes/feature.spec.unit.ts
@@ -1,0 +1,59 @@
+import { Readable } from 'stream';
+import { getPullRequestChanges } from './feature';
+import { AzureDevOpsError } from '../../../shared/errors';
+
+describe('getPullRequestChanges unit', () => {
+  test('should retrieve changes, evaluations, and file patches', async () => {
+    const mockConnection: any = {
+      getGitApi: jest.fn().mockResolvedValue({
+        getPullRequestIterations: jest.fn().mockResolvedValue([{ id: 1 }]),
+        getPullRequestIterationChanges: jest.fn().mockResolvedValue({
+          changeEntries: [
+            {
+              item: {
+                path: '/file.txt',
+                objectId: 'new',
+                originalObjectId: 'old',
+              },
+            },
+          ],
+        }),
+        getBlobContent: jest.fn().mockImplementation((_, sha: string) => {
+          const content = sha === 'old' ? 'old line\n' : 'new line\n';
+          return Promise.resolve(Readable.from([content]));
+        }),
+      }),
+      getPolicyApi: jest.fn().mockResolvedValue({
+        getPolicyEvaluations: jest.fn().mockResolvedValue([{ id: '1' }]),
+      }),
+    };
+
+    const result = await getPullRequestChanges(mockConnection, {
+      projectId: 'p',
+      repositoryId: 'r',
+      pullRequestId: 1,
+    });
+
+    expect(result.evaluations).toHaveLength(1);
+    expect(result.files).toHaveLength(1);
+    const patch = result.files[0].patch;
+    expect(patch).toContain('-old line');
+    expect(patch).toContain('+new line');
+  });
+
+  test('should throw when no iterations found', async () => {
+    const mockConnection: any = {
+      getGitApi: jest.fn().mockResolvedValue({
+        getPullRequestIterations: jest.fn().mockResolvedValue([]),
+      }),
+    };
+
+    await expect(
+      getPullRequestChanges(mockConnection, {
+        projectId: 'p',
+        repositoryId: 'r',
+        pullRequestId: 1,
+      }),
+    ).rejects.toThrow(AzureDevOpsError);
+  });
+});

--- a/src/features/pull-requests/get-pull-request-changes/feature.ts
+++ b/src/features/pull-requests/get-pull-request-changes/feature.ts
@@ -1,0 +1,97 @@
+import { WebApi } from 'azure-devops-node-api';
+import { GitPullRequestIterationChanges } from 'azure-devops-node-api/interfaces/GitInterfaces';
+import { PolicyEvaluationRecord } from 'azure-devops-node-api/interfaces/PolicyInterfaces';
+import { createTwoFilesPatch } from 'diff';
+import { AzureDevOpsError } from '../../../shared/errors';
+
+export interface PullRequestChangesOptions {
+  projectId: string;
+  repositoryId: string;
+  pullRequestId: number;
+}
+
+export interface PullRequestChangesResponse {
+  changes: GitPullRequestIterationChanges;
+  evaluations: PolicyEvaluationRecord[];
+  files: Array<{ path: string; patch: string }>;
+}
+
+/**
+ * Retrieve changes and policy evaluation status for a pull request
+ */
+export async function getPullRequestChanges(
+  connection: WebApi,
+  options: PullRequestChangesOptions,
+): Promise<PullRequestChangesResponse> {
+  try {
+    const gitApi = await connection.getGitApi();
+    const iterations = await gitApi.getPullRequestIterations(
+      options.repositoryId,
+      options.pullRequestId,
+      options.projectId,
+    );
+    if (!iterations || iterations.length === 0) {
+      throw new AzureDevOpsError('No iterations found for pull request');
+    }
+    const latest = iterations[iterations.length - 1];
+    const changes = await gitApi.getPullRequestIterationChanges(
+      options.repositoryId,
+      options.pullRequestId,
+      latest.id!,
+      options.projectId,
+    );
+
+    const files = await Promise.all(
+      (changes.changeEntries || []).map(async (entry) => {
+        const path = entry.item?.path || '';
+        let base = '';
+        let head = '';
+
+        if (entry.item?.originalObjectId) {
+          const stream = await gitApi.getBlobContent(
+            options.repositoryId,
+            entry.item.originalObjectId,
+            options.projectId,
+          );
+          base = await streamToString(stream);
+        }
+
+        if (entry.item?.objectId) {
+          const stream = await gitApi.getBlobContent(
+            options.repositoryId,
+            entry.item.objectId,
+            options.projectId,
+          );
+          head = await streamToString(stream);
+        }
+
+        const patch = createTwoFilesPatch(path, path, base, head);
+        return { path, patch };
+      }),
+    );
+
+    const policyApi = await connection.getPolicyApi();
+    const artifactId = `vstfs:///CodeReview/CodeReviewId/${options.projectId}/${options.pullRequestId}`;
+    const evaluations = await policyApi.getPolicyEvaluations(
+      options.projectId,
+      artifactId,
+    );
+
+    return { changes, evaluations, files };
+  } catch (error) {
+    if (error instanceof AzureDevOpsError) {
+      throw error;
+    }
+    throw new Error(
+      `Failed to get pull request changes: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+async function streamToString(stream: NodeJS.ReadableStream): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}

--- a/src/features/pull-requests/get-pull-request-changes/index.ts
+++ b/src/features/pull-requests/get-pull-request-changes/index.ts
@@ -1,0 +1,1 @@
+export * from './feature';

--- a/src/features/pull-requests/index.spec.unit.ts
+++ b/src/features/pull-requests/index.spec.unit.ts
@@ -6,6 +6,7 @@ import { listPullRequests } from './list-pull-requests';
 import { getPullRequestComments } from './get-pull-request-comments';
 import { addPullRequestComment } from './add-pull-request-comment';
 import { AddPullRequestCommentSchema } from './schemas';
+import { getPullRequestChanges } from './get-pull-request-changes';
 
 // Mock the imported modules
 jest.mock('./create-pull-request', () => ({
@@ -24,6 +25,10 @@ jest.mock('./add-pull-request-comment', () => ({
   addPullRequestComment: jest.fn(),
 }));
 
+jest.mock('./get-pull-request-changes', () => ({
+  getPullRequestChanges: jest.fn(),
+}));
+
 describe('Pull Requests Request Handlers', () => {
   const mockConnection = {} as WebApi;
 
@@ -34,6 +39,7 @@ describe('Pull Requests Request Handlers', () => {
         'list_pull_requests',
         'get_pull_request_comments',
         'add_pull_request_comment',
+        'get_pull_request_changes',
       ];
       validTools.forEach((tool) => {
         const request = {
@@ -214,6 +220,29 @@ describe('Pull Requests Request Handlers', () => {
 
       // Restore the original parse function
       AddPullRequestCommentSchema.parse = originalParse;
+    });
+
+    it('should handle get_pull_request_changes request', async () => {
+      const mockResult = {
+        changes: { changeEntries: [] },
+        evaluations: [],
+        files: [],
+      };
+      (getPullRequestChanges as jest.Mock).mockResolvedValue(mockResult);
+
+      const request = {
+        params: {
+          name: 'get_pull_request_changes',
+          arguments: { repositoryId: 'test-repo', pullRequestId: 1 },
+        },
+        method: 'tools/call',
+      } as CallToolRequest;
+
+      const response = await handlePullRequestsRequest(mockConnection, request);
+      expect(JSON.parse(response.content[0].text as string)).toEqual(
+        mockResult,
+      );
+      expect(getPullRequestChanges).toHaveBeenCalled();
     });
 
     it('should throw error for unknown tool', async () => {

--- a/src/features/pull-requests/index.ts
+++ b/src/features/pull-requests/index.ts
@@ -5,6 +5,7 @@ export * from './list-pull-requests';
 export * from './get-pull-request-comments';
 export * from './add-pull-request-comment';
 export * from './update-pull-request';
+export * from './get-pull-request-changes';
 
 // Export tool definitions
 export * from './tool-definitions';
@@ -23,11 +24,13 @@ import {
   GetPullRequestCommentsSchema,
   AddPullRequestCommentSchema,
   UpdatePullRequestSchema,
+  GetPullRequestChangesSchema,
   createPullRequest,
   listPullRequests,
   getPullRequestComments,
   addPullRequestComment,
   updatePullRequest,
+  getPullRequestChanges,
 } from './';
 
 /**
@@ -43,6 +46,7 @@ export const isPullRequestsRequest: RequestIdentifier = (
     'get_pull_request_comments',
     'add_pull_request_comment',
     'update_pull_request',
+    'get_pull_request_changes',
   ].includes(toolName);
 };
 
@@ -142,6 +146,19 @@ export const handlePullRequestsRequest: RequestHandler = async (
         projectId: params.projectId ?? defaultProject,
       };
       const result = await updatePullRequest(fixedParams);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+    case 'get_pull_request_changes': {
+      const params = GetPullRequestChangesSchema.parse(
+        request.params.arguments,
+      );
+      const result = await getPullRequestChanges(connection, {
+        projectId: params.projectId ?? defaultProject,
+        repositoryId: params.repositoryId,
+        pullRequestId: params.pullRequestId,
+      });
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
       };

--- a/src/features/pull-requests/schemas.ts
+++ b/src/features/pull-requests/schemas.ts
@@ -219,3 +219,19 @@ export const UpdatePullRequestSchema = z.object({
     .optional()
     .describe('Additional properties to update on the pull request'),
 });
+
+/**
+ * Schema for getting pull request changes and policy evaluations
+ */
+export const GetPullRequestChangesSchema = z.object({
+  projectId: z
+    .string()
+    .optional()
+    .describe(`The ID or name of the project (Default: ${defaultProject})`),
+  organizationId: z
+    .string()
+    .optional()
+    .describe(`The ID or name of the organization (Default: ${defaultOrg})`),
+  repositoryId: z.string().describe('The ID or name of the repository'),
+  pullRequestId: z.number().describe('The ID of the pull request'),
+});

--- a/src/features/pull-requests/tool-definitions.ts
+++ b/src/features/pull-requests/tool-definitions.ts
@@ -6,6 +6,7 @@ import {
   GetPullRequestCommentsSchema,
   AddPullRequestCommentSchema,
   UpdatePullRequestSchema,
+  GetPullRequestChangesSchema,
 } from './schemas';
 
 /**
@@ -38,5 +39,11 @@ export const pullRequestsTools: ToolDefinition[] = [
     description:
       'Update an existing pull request with new properties, link work items, and manage reviewers',
     inputSchema: zodToJsonSchema(UpdatePullRequestSchema),
+  },
+  {
+    name: 'get_pull_request_changes',
+    description:
+      'Get the files changed in a pull request and the status of policy evaluations',
+    inputSchema: zodToJsonSchema(GetPullRequestChangesSchema),
   },
 ];

--- a/src/features/repositories/create-branch/feature.spec.unit.ts
+++ b/src/features/repositories/create-branch/feature.spec.unit.ts
@@ -1,0 +1,40 @@
+import { createBranch } from './feature';
+import { AzureDevOpsError } from '../../../shared/errors';
+
+describe('createBranch unit', () => {
+  test('should create branch when source exists', async () => {
+    const updateRefs = jest.fn().mockResolvedValue([{ success: true }]);
+    const mockConnection: any = {
+      getGitApi: jest.fn().mockResolvedValue({
+        getBranch: jest.fn().mockResolvedValue({ commit: { commitId: 'abc' } }),
+        updateRefs,
+      }),
+    };
+
+    await createBranch(mockConnection, {
+      projectId: 'p',
+      repositoryId: 'r',
+      sourceBranch: 'main',
+      newBranch: 'feature',
+    });
+
+    expect(updateRefs).toHaveBeenCalled();
+  });
+
+  test('should throw error when source branch missing', async () => {
+    const mockConnection: any = {
+      getGitApi: jest.fn().mockResolvedValue({
+        getBranch: jest.fn().mockResolvedValue(null),
+      }),
+    };
+
+    await expect(
+      createBranch(mockConnection, {
+        projectId: 'p',
+        repositoryId: 'r',
+        sourceBranch: 'missing',
+        newBranch: 'feature',
+      }),
+    ).rejects.toThrow(AzureDevOpsError);
+  });
+});

--- a/src/features/repositories/create-branch/feature.ts
+++ b/src/features/repositories/create-branch/feature.ts
@@ -1,0 +1,49 @@
+import { WebApi } from 'azure-devops-node-api';
+import { GitRefUpdate } from 'azure-devops-node-api/interfaces/GitInterfaces';
+import { AzureDevOpsError } from '../../../shared/errors';
+import { CreateBranchOptions } from '../types';
+
+/**
+ * Create a new branch from an existing one
+ */
+export async function createBranch(
+  connection: WebApi,
+  options: CreateBranchOptions,
+): Promise<void> {
+  try {
+    const gitApi = await connection.getGitApi();
+    const source = await gitApi.getBranch(
+      options.repositoryId,
+      options.sourceBranch,
+      options.projectId,
+    );
+    const commitId = source?.commit?.commitId;
+    if (!commitId) {
+      throw new AzureDevOpsError(
+        `Source branch '${options.sourceBranch}' not found`,
+      );
+    }
+
+    const refUpdate: GitRefUpdate = {
+      name: `refs/heads/${options.newBranch}`,
+      oldObjectId: '0000000000000000000000000000000000000000',
+      newObjectId: commitId,
+    };
+
+    const result = await gitApi.updateRefs(
+      [refUpdate],
+      options.repositoryId,
+      options.projectId,
+    );
+    if (!result.every((r) => r.success)) {
+      throw new AzureDevOpsError('Failed to create new branch');
+    }
+  } catch (error) {
+    if (error instanceof AzureDevOpsError) {
+      throw error;
+    }
+    throw new Error(
+      `Failed to create branch: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/src/features/repositories/create-branch/index.ts
+++ b/src/features/repositories/create-branch/index.ts
@@ -1,0 +1,1 @@
+export * from './feature';

--- a/src/features/repositories/create-commit/feature.spec.unit.ts
+++ b/src/features/repositories/create-commit/feature.spec.unit.ts
@@ -1,0 +1,68 @@
+import { Readable } from 'stream';
+import { createCommit } from './feature';
+import { AzureDevOpsError } from '../../../shared/errors';
+
+describe('createCommit unit', () => {
+  test('should create push with provided changes', async () => {
+    const createPush = jest.fn().mockResolvedValue({});
+    const mockConnection: any = {
+      getGitApi: jest.fn().mockResolvedValue({
+        getBranch: jest
+          .fn()
+          .mockResolvedValue({ commit: { commitId: 'base' } }),
+        getItemContent: jest
+          .fn()
+          .mockResolvedValue(Readable.from(['console.log("hello");'])),
+        createPush,
+      }),
+    };
+
+    await createCommit(mockConnection, {
+      projectId: 'p',
+      repositoryId: 'r',
+      branchName: 'main',
+      commitMessage: 'msg',
+      changes: [
+        {
+          path: '/file.ts',
+          originalCode: 'console.log("hello");',
+          newCode: 'console.log("world");',
+        },
+        { path: '/new.txt', newCode: 'hi' },
+      ],
+    });
+
+    expect(createPush).toHaveBeenCalled();
+    const payload = createPush.mock.calls[0][0];
+    expect(payload.commits[0].changes).toHaveLength(2);
+  });
+
+  test('should throw when snippet not found', async () => {
+    const mockConnection: any = {
+      getGitApi: jest.fn().mockResolvedValue({
+        getBranch: jest
+          .fn()
+          .mockResolvedValue({ commit: { commitId: 'base' } }),
+        getItemContent: jest
+          .fn()
+          .mockResolvedValue(Readable.from(['nothing here'])),
+      }),
+    };
+
+    await expect(
+      createCommit(mockConnection, {
+        projectId: 'p',
+        repositoryId: 'r',
+        branchName: 'main',
+        commitMessage: 'msg',
+        changes: [
+          {
+            path: '/file.ts',
+            originalCode: 'console.log("hello");',
+            newCode: 'console.log("world");',
+          },
+        ],
+      }),
+    ).rejects.toThrow(AzureDevOpsError);
+  });
+});

--- a/src/features/repositories/create-commit/feature.ts
+++ b/src/features/repositories/create-commit/feature.ts
@@ -1,0 +1,114 @@
+import { WebApi } from 'azure-devops-node-api';
+import {
+  GitVersionType,
+  GitRefUpdate,
+  GitChange,
+  VersionControlChangeType,
+  ItemContentType,
+} from 'azure-devops-node-api/interfaces/GitInterfaces';
+import { AzureDevOpsError } from '../../../shared/errors';
+import { CreateCommitOptions } from '../types';
+
+async function streamToString(stream: NodeJS.ReadableStream): Promise<string> {
+  const chunks: Buffer[] = [];
+  return await new Promise<string>((resolve, reject) => {
+    stream.on('data', (c) => chunks.push(Buffer.from(c)));
+    stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    stream.on('error', (err) => reject(err));
+  });
+}
+
+/**
+ * Create a commit with multiple file changes
+ */
+export async function createCommit(
+  connection: WebApi,
+  options: CreateCommitOptions,
+): Promise<void> {
+  try {
+    const gitApi = await connection.getGitApi();
+    const branch = await gitApi.getBranch(
+      options.repositoryId,
+      options.branchName,
+      options.projectId,
+    );
+    const baseCommit = branch?.commit?.commitId;
+    if (!baseCommit) {
+      throw new AzureDevOpsError(`Branch '${options.branchName}' not found`);
+    }
+
+    const changes: GitChange[] = [];
+
+    for (const file of options.changes) {
+      if (file.delete) {
+        changes.push({
+          changeType: VersionControlChangeType.Delete,
+          item: { path: file.path },
+        });
+        continue;
+      }
+
+      if (file.originalCode) {
+        const stream = await gitApi.getItemContent(
+          options.repositoryId,
+          file.path,
+          options.projectId,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          false,
+          { version: options.branchName, versionType: GitVersionType.Branch },
+          true,
+        );
+        const original = stream ? await streamToString(stream) : '';
+        if (!original.includes(file.originalCode)) {
+          throw new AzureDevOpsError(
+            `Original code snippet not found in ${file.path}`,
+          );
+        }
+        const updated = original.replace(file.originalCode, file.newCode ?? '');
+        changes.push({
+          changeType: VersionControlChangeType.Edit,
+          item: { path: file.path },
+          newContent: {
+            content: updated,
+            contentType: ItemContentType.RawText,
+          },
+        });
+      } else {
+        changes.push({
+          changeType: VersionControlChangeType.Add,
+          item: { path: file.path },
+          newContent: {
+            content: file.newCode || '',
+            contentType: ItemContentType.RawText,
+          },
+        });
+      }
+    }
+
+    const commit = {
+      comment: options.commitMessage,
+      changes,
+    };
+
+    const refUpdate: GitRefUpdate = {
+      name: `refs/heads/${options.branchName}`,
+      oldObjectId: baseCommit,
+    };
+
+    await gitApi.createPush(
+      { commits: [commit], refUpdates: [refUpdate] },
+      options.repositoryId,
+      options.projectId,
+    );
+  } catch (error) {
+    if (error instanceof AzureDevOpsError) {
+      throw error;
+    }
+    throw new Error(
+      `Failed to create commit: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/src/features/repositories/create-commit/index.ts
+++ b/src/features/repositories/create-commit/index.ts
@@ -1,0 +1,1 @@
+export * from './feature';

--- a/src/features/repositories/get-repository-tree/feature.spec.unit.ts
+++ b/src/features/repositories/get-repository-tree/feature.spec.unit.ts
@@ -1,0 +1,76 @@
+import { getRepositoryTree } from './feature';
+import { AzureDevOpsError } from '../../../shared/errors';
+
+describe('getRepositoryTree unit', () => {
+  test('should build tree structure from root', async () => {
+    const mockConnection: any = {
+      getGitApi: jest.fn().mockResolvedValue({
+        getRepository: jest.fn().mockResolvedValue({
+          id: '1',
+          name: 'test-repo',
+          defaultBranch: 'refs/heads/main',
+        }),
+        getItems: jest.fn().mockResolvedValue([
+          { path: '/', isFolder: true },
+          { path: '/README.md', isFolder: false },
+          { path: '/src', isFolder: true },
+          { path: '/src/index.ts', isFolder: false },
+        ]),
+      }),
+    };
+
+    const result = await getRepositoryTree(mockConnection, {
+      projectId: 'proj',
+      repositoryId: '1',
+    });
+
+    expect(result.name).toBe('test-repo');
+    expect(result.stats.files).toBe(2);
+    expect(result.stats.directories).toBe(1);
+    expect(result.tree.length).toBe(3);
+  });
+
+  test('should respect depth when provided', async () => {
+    const mockConnection: any = {
+      getGitApi: jest.fn().mockResolvedValue({
+        getRepository: jest.fn().mockResolvedValue({
+          id: '1',
+          name: 'test-repo',
+          defaultBranch: 'refs/heads/main',
+        }),
+        getItems: jest.fn().mockResolvedValue([
+          { path: '/src', isFolder: true },
+          { path: '/src/index.ts', isFolder: false },
+          { path: '/src/utils', isFolder: true },
+          { path: '/src/utils/helper.ts', isFolder: false },
+        ]),
+      }),
+    };
+
+    const result = await getRepositoryTree(mockConnection, {
+      projectId: 'proj',
+      repositoryId: '1',
+      path: '/src',
+      depth: 1,
+    });
+
+    expect(result.tree).toHaveLength(2);
+    expect(result.stats.files).toBe(1);
+    expect(result.stats.directories).toBe(1);
+  });
+
+  test('should throw AzureDevOpsError when repository not found', async () => {
+    const mockConnection: any = {
+      getGitApi: jest.fn().mockResolvedValue({
+        getRepository: jest.fn().mockResolvedValue(null),
+      }),
+    };
+
+    await expect(
+      getRepositoryTree(mockConnection, {
+        projectId: 'p',
+        repositoryId: 'missing',
+      }),
+    ).rejects.toThrow(AzureDevOpsError);
+  });
+});

--- a/src/features/repositories/get-repository-tree/feature.ts
+++ b/src/features/repositories/get-repository-tree/feature.ts
@@ -1,0 +1,96 @@
+import { WebApi } from 'azure-devops-node-api';
+import {
+  GitVersionType,
+  VersionControlRecursionType,
+  GitObjectType,
+} from 'azure-devops-node-api/interfaces/GitInterfaces';
+import { AzureDevOpsError } from '../../../shared/errors';
+import {
+  GetRepositoryTreeOptions,
+  RepositoryTreeItem,
+  RepositoryTreeResponse,
+} from '../types';
+
+/**
+ * Get tree view of files/directories in a repository starting at an optional path
+ */
+export async function getRepositoryTree(
+  connection: WebApi,
+  options: GetRepositoryTreeOptions,
+): Promise<RepositoryTreeResponse> {
+  try {
+    const gitApi = await connection.getGitApi();
+
+    const repository = await gitApi.getRepository(
+      options.repositoryId,
+      options.projectId,
+    );
+    if (!repository || !repository.id) {
+      throw new AzureDevOpsError(
+        `Repository '${options.repositoryId}' not found in project '${options.projectId}'`,
+      );
+    }
+
+    const defaultBranch = repository.defaultBranch;
+    if (!defaultBranch) {
+      throw new AzureDevOpsError('Default branch not found');
+    }
+    const branchRef = defaultBranch.replace('refs/heads/', '');
+
+    const rootPath = options.path ?? '/';
+    const items = await gitApi.getItems(
+      repository.id,
+      options.projectId,
+      rootPath,
+      VersionControlRecursionType.Full,
+      true,
+      false,
+      false,
+      false,
+      {
+        version: branchRef,
+        versionType: GitVersionType.Branch,
+      },
+    );
+
+    const treeItems: RepositoryTreeItem[] = [];
+    const stats = { directories: 0, files: 0 };
+
+    for (const item of items) {
+      const path = item.path || '';
+      if (path === rootPath || item.gitObjectType === GitObjectType.Bad) {
+        continue;
+      }
+      const relative =
+        rootPath === '/'
+          ? path.replace(/^\//, '')
+          : path.slice(rootPath.length + 1);
+      const level = relative.split('/').length;
+      if (options.depth && options.depth > 0 && level > options.depth) {
+        continue;
+      }
+      const isFolder = !!item.isFolder;
+      treeItems.push({
+        name: relative.split('/').pop() || '',
+        path,
+        isFolder,
+        level,
+      });
+      if (isFolder) stats.directories++;
+      else stats.files++;
+    }
+
+    return {
+      name: repository.name || options.repositoryId,
+      tree: treeItems,
+      stats,
+    };
+  } catch (error) {
+    if (error instanceof AzureDevOpsError) {
+      throw error;
+    }
+    throw new Error(
+      `Failed to get repository tree: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/src/features/repositories/get-repository-tree/index.ts
+++ b/src/features/repositories/get-repository-tree/index.ts
@@ -1,0 +1,1 @@
+export * from './feature';

--- a/src/features/repositories/index.ts
+++ b/src/features/repositories/index.ts
@@ -8,6 +8,9 @@ export * from './get-repository-details';
 export * from './list-repositories';
 export * from './get-file-content';
 export * from './get-all-repositories-tree';
+export * from './get-repository-tree';
+export * from './create-branch';
+export * from './create-commit';
 
 // Export tool definitions
 export * from './tool-definitions';
@@ -27,11 +30,17 @@ import {
   ListRepositoriesSchema,
   GetFileContentSchema,
   GetAllRepositoriesTreeSchema,
+  GetRepositoryTreeSchema,
+  CreateBranchSchema,
+  CreateCommitSchema,
   getRepository,
   getRepositoryDetails,
   listRepositories,
   getFileContent,
   getAllRepositoriesTree,
+  getRepositoryTree,
+  createBranch,
+  createCommit,
   formatRepositoryTree,
 } from './';
 
@@ -48,6 +57,9 @@ export const isRepositoriesRequest: RequestIdentifier = (
     'list_repositories',
     'get_file_content',
     'get_all_repositories_tree',
+    'get_repository_tree',
+    'create_branch',
+    'create_commit',
   ].includes(toolName);
 };
 
@@ -144,6 +156,41 @@ export const handleRepositoriesRequest: RequestHandler = async (
 
       return {
         content: [{ type: 'text', text: formattedOutput }],
+      };
+    }
+    case 'get_repository_tree': {
+      const args = GetRepositoryTreeSchema.parse(request.params.arguments);
+      const result = await getRepositoryTree(connection, {
+        ...args,
+        projectId: args.projectId ?? defaultProject,
+      });
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    }
+    case 'create_branch': {
+      const args = CreateBranchSchema.parse(request.params.arguments);
+      await createBranch(connection, {
+        ...args,
+        projectId: args.projectId ?? defaultProject,
+      });
+      return {
+        content: [{ type: 'text', text: 'Branch created successfully' }],
+      };
+    }
+    case 'create_commit': {
+      const args = CreateCommitSchema.parse(request.params.arguments);
+      await createCommit(connection, {
+        ...args,
+        projectId: args.projectId ?? defaultProject,
+      });
+      return {
+        content: [{ type: 'text', text: 'Commit created successfully' }],
       };
     }
     default:

--- a/src/features/repositories/schemas.ts
+++ b/src/features/repositories/schemas.ts
@@ -134,3 +134,81 @@ export const GetAllRepositoriesTreeSchema = z.object({
       'File pattern (wildcard characters allowed) to filter files by within each repository',
     ),
 });
+
+/**
+ * Schema for getting a tree for a single repository
+ */
+export const GetRepositoryTreeSchema = z.object({
+  projectId: z
+    .string()
+    .optional()
+    .describe(`The ID or name of the project (Default: ${defaultProject})`),
+  organizationId: z
+    .string()
+    .optional()
+    .describe(`The ID or name of the organization (Default: ${defaultOrg})`),
+  repositoryId: z.string().describe('The ID or name of the repository'),
+  path: z
+    .string()
+    .optional()
+    .default('/')
+    .describe('Path within the repository to start from'),
+  depth: z
+    .number()
+    .int()
+    .min(0)
+    .max(10)
+    .optional()
+    .default(0)
+    .describe('Maximum depth to traverse (0 = unlimited)'),
+});
+
+/**
+ * Schema for creating a new branch
+ */
+export const CreateBranchSchema = z.object({
+  projectId: z
+    .string()
+    .optional()
+    .describe(`The ID or name of the project (Default: ${defaultProject})`),
+  organizationId: z
+    .string()
+    .optional()
+    .describe(`The ID or name of the organization (Default: ${defaultOrg})`),
+  repositoryId: z.string().describe('The ID or name of the repository'),
+  sourceBranch: z.string().describe('Name of the branch to copy from'),
+  newBranch: z.string().describe('Name of the new branch to create'),
+});
+
+/**
+ * Schema for creating a commit with multiple file changes
+ */
+export const CreateCommitSchema = z.object({
+  projectId: z
+    .string()
+    .optional()
+    .describe(`The ID or name of the project (Default: ${defaultProject})`),
+  organizationId: z
+    .string()
+    .optional()
+    .describe(`The ID or name of the organization (Default: ${defaultOrg})`),
+  repositoryId: z.string().describe('The ID or name of the repository'),
+  branchName: z.string().describe('The branch to commit to'),
+  commitMessage: z.string().describe('Commit message'),
+  changes: z
+    .array(
+      z.object({
+        path: z.string().describe('File path within the repository'),
+        originalCode: z
+          .string()
+          .optional()
+          .describe('Original snippet to replace'),
+        newCode: z
+          .string()
+          .optional()
+          .describe('Replacement snippet or new file content'),
+        delete: z.boolean().optional().describe('Delete the file'),
+      }),
+    )
+    .describe('List of file changes'),
+});

--- a/src/features/repositories/tool-definitions.ts
+++ b/src/features/repositories/tool-definitions.ts
@@ -6,6 +6,9 @@ import {
   ListRepositoriesSchema,
   GetFileContentSchema,
   GetAllRepositoriesTreeSchema,
+  GetRepositoryTreeSchema,
+  CreateBranchSchema,
+  CreateCommitSchema,
 } from './schemas';
 
 /**
@@ -38,5 +41,21 @@ export const repositoriesTools: ToolDefinition[] = [
     description:
       'Displays a hierarchical tree view of files and directories across multiple Azure DevOps repositories within a project, based on their default branches',
     inputSchema: zodToJsonSchema(GetAllRepositoriesTreeSchema),
+  },
+  {
+    name: 'get_repository_tree',
+    description:
+      'Displays a hierarchical tree view of files and directories within a single repository starting from an optional path',
+    inputSchema: zodToJsonSchema(GetRepositoryTreeSchema),
+  },
+  {
+    name: 'create_branch',
+    description: 'Create a new branch from an existing one',
+    inputSchema: zodToJsonSchema(CreateBranchSchema),
+  },
+  {
+    name: 'create_commit',
+    description: 'Create a commit with a set of file changes on a branch',
+    inputSchema: zodToJsonSchema(CreateCommitSchema),
   },
 ];

--- a/src/features/repositories/types.ts
+++ b/src/features/repositories/types.ts
@@ -51,6 +51,58 @@ export interface GetAllRepositoriesTreeOptions {
 }
 
 /**
+ * Options for getting a repository tree starting at a specific path
+ */
+export interface GetRepositoryTreeOptions {
+  projectId: string;
+  repositoryId: string;
+  /**
+   * Path within the repository to start from. Defaults to '/'
+   */
+  path?: string;
+  /**
+   * Maximum depth to traverse (0 = unlimited)
+   */
+  depth?: number;
+}
+
+/**
+ * Options for creating a new branch from an existing one
+ */
+export interface CreateBranchOptions {
+  projectId: string;
+  repositoryId: string;
+  /** Source branch name to copy from */
+  sourceBranch: string;
+  /** Name of the new branch to create */
+  newBranch: string;
+}
+
+/**
+ * Description of a single file change for commit creation
+ */
+export interface FileChange {
+  path: string;
+  /** Snippet of original code to replace (omit for new files) */
+  originalCode?: string;
+  /** Replacement code or full content for new files */
+  newCode?: string;
+  /** If true, delete the file */
+  delete?: boolean;
+}
+
+/**
+ * Options for creating a commit with multiple file changes
+ */
+export interface CreateCommitOptions {
+  projectId: string;
+  repositoryId: string;
+  branchName: string;
+  commitMessage: string;
+  changes: FileChange[];
+}
+
+/**
  * Repository tree item representation for output
  */
 export interface RepositoryTreeItem {


### PR DESCRIPTION
## Summary
- list repository tree from any path and depth
- add branch creation and commit tools
- expose pull request changes and evaluation status
- rename package to @hmaldonadovilla and update documentation
- include unified diff patches when retrieving pull request changes

## Testing
- `npm test`
- `npm run lint`
- `node dist/...` (fails: Organization URL is required)


------
https://chatgpt.com/codex/tasks/task_e_68c2fefb18d8832c9faa83443be7d7db