### PR TITLE
fix: include diff content in pull request changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hmaldonadovilla/mcp-server-azure-devops",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hmaldonadovilla/mcp-server-azure-devops",
-      "version": "0.1.43",
+      "version": "0.1.44",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmaldonadovilla/mcp-server-azure-devops",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "description": "Azure DevOps reference server for the Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/features/pull-requests/get-pull-request-changes/feature.spec.unit.ts
+++ b/src/features/pull-requests/get-pull-request-changes/feature.spec.unit.ts
@@ -1,5 +1,6 @@
 import { getPullRequestChanges } from './feature';
 import { AzureDevOpsError } from '../../../shared/errors';
+import { Readable } from 'stream';
 
 describe('getPullRequestChanges unit', () => {
   test('should retrieve changes, evaluations, and patches', async () => {
@@ -17,12 +18,15 @@ describe('getPullRequestChanges unit', () => {
             },
           ],
         }),
-        getBlob: jest.fn().mockImplementation((_: string, sha: string) => {
-          const content = sha === 'new' ? 'new content\n' : 'old content\n';
-          return Promise.resolve({
-            content: Buffer.from(content).toString('base64'),
-          });
-        }),
+        getBlobContent: jest
+          .fn()
+          .mockImplementation((_: string, sha: string) => {
+            const content = sha === 'new' ? 'new content\n' : 'old content\n';
+            const stream = new Readable();
+            stream.push(content);
+            stream.push(null);
+            return Promise.resolve(stream);
+          }),
       }),
       getPolicyApi: jest.fn().mockResolvedValue({
         getPolicyEvaluations: jest.fn().mockResolvedValue([{ id: '1' }]),

--- a/src/types/diff.d.ts
+++ b/src/types/diff.d.ts
@@ -1,0 +1,1 @@
+declare module 'diff';


### PR DESCRIPTION
## Summary
- ensure get_pull_request_changes returns file diff content by reading blobs via stream
- add local type declaration for diff module
- bump version to 0.1.44

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c3e95696bc832c84429d9d88279ba6