### PR TITLE
docs: add documentation for pipeline run tools

### DIFF
--- a/docs/tools/pipelines.md
+++ b/docs/tools/pipelines.md
@@ -6,6 +6,10 @@ This document describes the tools available for working with Azure DevOps pipeli
 
 - [`list_pipelines`](#list_pipelines) - List pipelines in a project
 - [`get_pipeline`](#get_pipeline) - Get details of a specific pipeline
+- [`list_pipeline_runs`](#list_pipeline_runs) - List recent runs for a pipeline
+- [`get_pipeline_run`](#get_pipeline_run) - Get details for a specific pipeline run
+- [`pipeline_timeline`](#pipeline_timeline) - Retrieve the timeline for a pipeline run
+- [`get_pipeline_log`](#get_pipeline_log) - Retrieve log output for a pipeline run
 - [`trigger_pipeline`](#trigger_pipeline) - Trigger a pipeline run
 
 ## list_pipelines
@@ -127,6 +131,230 @@ const versionResult = await callTool('get_pipeline', {
   projectId: 'my-project',
   pipelineId: 4,
   pipelineVersion: 2,
+});
+```
+
+## list_pipeline_runs
+
+Lists recent runs for a specific pipeline.
+
+### Parameters
+
+| Parameter            | Type   | Required | Description                                                                 |
+| -------------------- | ------ | -------- | --------------------------------------------------------------------------- |
+| `projectId`          | string | No       | The ID or name of the project (Default: from environment)                   |
+| `pipelineId`         | number | Yes      | The numeric ID of the pipeline to query                                     |
+| `top`                | number | No       | Maximum number of runs to return (1-100, default 50)                        |
+| `continuationToken`  | string | No       | Token to retrieve the next page of results                                  |
+| `branch`             | string | No       | Filter by branch (accepts shorthand like `main` or full ref `refs/heads/*`) |
+| `state`              | string | No       | Filter by current run state (`notStarted`, `inProgress`, `completed`, etc.) |
+| `result`             | string | No       | Filter by final run result (`succeeded`, `failed`, etc.)                    |
+| `createdFrom`        | string | No       | Only include runs created at or after this ISO 8601 timestamp               |
+| `createdTo`          | string | No       | Only include runs created at or before this ISO 8601 timestamp              |
+| `orderBy`            | string | No       | Sort order for creation date (`createdDate desc` or `createdDate asc`)      |
+
+### Response
+
+Returns an object containing the runs and, when applicable, a continuation token:
+
+```json
+{
+  "runs": [
+    {
+      "id": 987,
+      "name": "20240220.1",
+      "state": "completed",
+      "result": "succeeded",
+      "createdDate": "2024-02-20T16:30:15.06Z",
+      "pipeline": {
+        "id": 4,
+        "name": "Node.js build pipeline"
+      }
+    }
+  ],
+  "continuationToken": "eyJwYWdlIjoyfQ=="
+}
+```
+
+### Error Handling
+
+- Returns `AzureDevOpsResourceNotFoundError` if the pipeline or project does not exist
+- Returns `AzureDevOpsAuthenticationError` if authentication fails
+- Returns generic error messages for other failures
+
+### Example Usage
+
+```javascript
+// List the 20 most recent runs on main
+const recentRuns = await callTool('list_pipeline_runs', {
+  pipelineId: 4,
+  top: 20,
+  branch: 'main',
+});
+
+// Fetch the next page using the continuation token
+const nextPage = await callTool('list_pipeline_runs', {
+  pipelineId: 4,
+  continuationToken: recentRuns.continuationToken,
+});
+```
+
+## get_pipeline_run
+
+Gets details for a specific pipeline run. Optionally validates that the run belongs to a particular pipeline.
+
+### Parameters
+
+| Parameter    | Type   | Required | Description                                                           |
+| -------------| ------ | -------- | --------------------------------------------------------------------- |
+| `projectId`  | string | No       | The ID or name of the project (Default: from environment)             |
+| `runId`      | number | Yes      | The numeric ID of the pipeline run to retrieve                        |
+| `pipelineId` | number | No       | Optional guard to ensure the run belongs to the specified pipeline ID |
+
+### Response
+
+Returns a pipeline run object including pipeline metadata, result, timing, and variables:
+
+```json
+{
+  "id": 987,
+  "name": "20240220.1",
+  "state": "completed",
+  "result": "succeeded",
+  "createdDate": "2024-02-20T16:30:15.06Z",
+  "finishedDate": "2024-02-20T16:34:02.47Z",
+  "pipeline": {
+    "id": 4,
+    "name": "Node.js build pipeline"
+  }
+}
+```
+
+### Error Handling
+
+- Returns `AzureDevOpsResourceNotFoundError` if the run or project does not exist, or if it fails the pipeline guard
+- Returns `AzureDevOpsAuthenticationError` if authentication fails
+- Returns generic error messages for other failures
+
+### Example Usage
+
+```javascript
+// Retrieve a run and ensure it belongs to pipeline 4
+const run = await callTool('get_pipeline_run', {
+  pipelineId: 4,
+  runId: 987,
+});
+```
+
+## pipeline_timeline
+
+Retrieves the timeline for a pipeline run, optionally filtering the returned records by state or result.
+
+### Parameters
+
+| Parameter    | Type             | Required | Description                                                                 |
+| -------------| ---------------- | -------- | --------------------------------------------------------------------------- |
+| `projectId`  | string           | No       | The ID or name of the project (Default: from environment)                   |
+| `runId`      | number           | Yes      | The numeric ID of the pipeline run                                          |
+| `timelineId` | string           | No       | Optional timeline identifier to target a specific timeline instance         |
+| `pipelineId` | number           | No       | Optional pipeline numeric ID for reference                                  |
+| `state`      | string or array  | No       | Filter timeline records by state (`pending`, `inProgress`, `completed`)     |
+| `result`     | string or array  | No       | Filter timeline records by result (`succeeded`, `failed`, `skipped`, etc.)  |
+
+### Response
+
+Returns the timeline object from Azure DevOps, including the filtered `records` collection:
+
+```json
+{
+  "id": "a1b2c3d4",
+  "changeId": 14,
+  "lastChangedOn": "2024-02-20T16:33:59.9Z",
+  "records": [
+    {
+      "id": "stage-job",
+      "type": "Job",
+      "name": "Build",
+      "state": "completed",
+      "result": "succeeded",
+      "startTime": "2024-02-20T16:30:30.0Z",
+      "finishTime": "2024-02-20T16:33:45.5Z"
+    }
+  ]
+}
+```
+
+### Error Handling
+
+- Returns `AzureDevOpsResourceNotFoundError` if the timeline or project does not exist
+- Returns `AzureDevOpsAuthenticationError` if authentication fails
+- Returns generic error messages for other failures
+
+### Example Usage
+
+```javascript
+// Retrieve only failed records for a run
+const timeline = await callTool('pipeline_timeline', {
+  runId: 987,
+  result: 'failed',
+});
+```
+
+## get_pipeline_log
+
+Retrieves the contents of a specific pipeline log. Logs can be returned as plain text or structured JSON.
+
+### Parameters
+
+| Parameter    | Type   | Required | Description                                                                   |
+| -------------| ------ | -------- | ----------------------------------------------------------------------------- |
+| `projectId`  | string | No       | The ID or name of the project (Default: from environment)                     |
+| `runId`      | number | Yes      | The numeric ID of the pipeline run                                            |
+| `logId`      | number | Yes      | The log identifier provided in the timeline records                           |
+| `format`     | string | No       | `plain` (default) to receive newline-delimited text or `json` for structured data |
+| `startLine`  | number | No       | Optional start line when retrieving a segment of the log                      |
+| `endLine`    | number | No       | Optional end line when retrieving a segment of the log                        |
+| `pipelineId` | number | No       | Optional pipeline numeric ID for reference                                    |
+
+### Response
+
+Depending on the requested format, returns either a string containing the log lines separated by `\n`, or a JSON object:
+
+```json
+// Plain text format
+"Downloading dependencies\nRunning tests\nAll tests passed"
+
+// JSON format
+[
+  {
+    "line": 1,
+    "content": "Downloading dependencies"
+  }
+]
+```
+
+### Error Handling
+
+- Returns `AzureDevOpsResourceNotFoundError` if the log or project does not exist
+- Returns `AzureDevOpsAuthenticationError` if authentication fails
+- Returns generic error messages for other failures
+
+### Example Usage
+
+```javascript
+// Fetch a portion of a log as plain text
+const logSnippet = await callTool('get_pipeline_log', {
+  runId: 987,
+  logId: 42,
+  startLine: 1,
+  endLine: 100,
+});
+
+// Retrieve the same log as structured JSON
+const logJson = await callTool('get_pipeline_log', {
+  runId: 987,
+  logId: 42,
+  format: 'json',
 });
 ```
 


### PR DESCRIPTION
## Summary
- document the list_pipeline_runs, get_pipeline_run, pipeline_timeline, and get_pipeline_log tools
- update the pipelines tool guide table of contents to include the new entries

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68db80a37e18832cb67a559698e455a7