### PR TITLE
feat: add pull request checks tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ logs/
 *.log 
 # Snyk Security Extension - AI Rules (auto-generated)
 .cursor/rules/snyk_rules.mdc
+
+# Patches
+diffs/

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ The Azure DevOps MCP server provides a variety of tools for interacting with Azu
 - [`get_pull_request_comments`](https://github.com/hmaldonadovilla/mcp-server-azure-devops/blob/main/docs/tools/pull-requests.md#get_pull_request_comments) - Get comments from a pull request
 - [`update_pull_request`](https://github.com/hmaldonadovilla/mcp-server-azure-devops/blob/main/docs/tools/pull-requests.md#update_pull_request) - Update an existing pull request (title, description, status, draft state, reviewers, work items)
 - [`get_pull_request_changes`](https://github.com/hmaldonadovilla/mcp-server-azure-devops/blob/main/docs/tools/pull-requests.md#get_pull_request_changes) - List changes in a pull request and policy evaluation status
+- [`get_pull_request_checks`](https://github.com/hmaldonadovilla/mcp-server-azure-devops/blob/main/docs/tools/pull-requests.md#get_pull_request_checks) - Summarize status checks, policy evaluations, and their related pipelines
 
 For comprehensive documentation on all tools, see the [Tools Documentation](https://github.com/hmaldonadovilla/mcp-server-azure-devops/tree/main/docs/tools).
 

--- a/docs/tools/pull-requests.md
+++ b/docs/tools/pull-requests.md
@@ -1013,3 +1013,59 @@ Each file entry has the shape:
   "patch": "@@ -1,2 +1,2 @@\n-old\n+new\n"
 }
 ```
+
+## get_pull_request_checks
+
+Summarises the latest status checks (builds, validations, custom checks) and policy evaluations applied to a pull request, including the pipeline/run identifiers you need to investigate failures.
+
+### Parameters
+
+```json
+{
+  "projectId": "MyProject",
+  "repositoryId": "MyRepo",
+  "pullRequestId": 42
+}
+```
+
+### Response
+
+Returns an object with two arrays:
+
+- `statuses`: Check runs reported through the PR status API. Each entry includes the check `state`, description, status context (`name`/`genre`), and a `pipeline` object with any discovered `pipelineId`, `definitionId`, `runId`/`buildId`, and `targetUrl`.
+- `policyEvaluations`: Policy evaluation records (e.g., build validations, required reviews). Each entry includes policy metadata, whether it is blocking, the evaluation status, a friendly `displayName`, and a `pipeline` object mirroring the identifiers above when the policy is backed by a pipeline.
+
+Example response (trimmed):
+
+```json
+{
+  "statuses": [
+    {
+      "id": 17,
+      "state": "failed",
+      "description": "CI build",
+      "context": { "name": "CI", "genre": "continuous-integration" },
+      "pipeline": {
+        "pipelineId": 55,
+        "runId": 123,
+        "targetUrl": "https://dev.azure.com/org/project/_apis/pipelines/55/runs/123?view=results"
+      }
+    }
+  ],
+  "policyEvaluations": [
+    {
+      "evaluationId": "eval-1",
+      "status": "rejected",
+      "displayName": "CI Build",
+      "isBlocking": true,
+      "pipeline": {
+        "definitionId": 987,
+        "buildId": 456,
+        "targetUrl": "https://dev.azure.com/org/project/_build/results?buildId=456"
+      }
+    }
+  ]
+}
+```
+
+Use the surfaced `pipelineId` and `runId` values with the pipeline tools (`get_pipeline_run`, `pipeline_timeline`, `get_pipeline_log`, etc.) to drill into the specific validation that is blocking the pull request.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hmaldonadovilla/mcp-server-azure-devops",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hmaldonadovilla/mcp-server-azure-devops",
-      "version": "0.1.52",
+      "version": "0.1.53",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmaldonadovilla/mcp-server-azure-devops",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "description": "Azure DevOps reference server for the Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/features/pull-requests/get-pull-request-checks/feature.spec.unit.ts
+++ b/src/features/pull-requests/get-pull-request-checks/feature.spec.unit.ts
@@ -1,0 +1,117 @@
+import { getPullRequestChecks } from './feature';
+import { GitStatusState } from 'azure-devops-node-api/interfaces/GitInterfaces';
+import { PolicyEvaluationStatus } from 'azure-devops-node-api/interfaces/PolicyInterfaces';
+import { AzureDevOpsError } from '../../../shared/errors';
+
+describe('getPullRequestChecks', () => {
+  it('returns status checks and policy evaluations with pipeline references', async () => {
+    const statusRecords: any[] = [
+      {
+        id: 10,
+        state: GitStatusState.Failed,
+        description: 'CI build',
+        context: { name: 'CI', genre: 'continuous-integration' },
+        targetUrl:
+          'https://dev.azure.com/org/project/_apis/pipelines/55/runs/123?view=results',
+        creationDate: new Date('2024-01-01T00:00:00Z'),
+        updatedDate: new Date('2024-01-01T01:00:00Z'),
+      },
+      {
+        id: 11,
+        state: GitStatusState.Succeeded,
+        description: 'Lint checks',
+        context: { name: 'Lint', genre: 'validation' },
+        targetUrl:
+          'https://dev.azure.com/org/project/_build/results?buildId=456&definitionId=789',
+        creationDate: new Date('2024-02-01T00:00:00Z'),
+        updatedDate: new Date('2024-02-01T01:00:00Z'),
+      },
+    ];
+
+    const evaluationRecords: any[] = [
+      {
+        evaluationId: 'eval-1',
+        status: PolicyEvaluationStatus.Rejected,
+        configuration: {
+          id: 7,
+          revision: 3,
+          isBlocking: true,
+          isEnabled: true,
+          type: {
+            id: 'policy-guid',
+            displayName: 'Build',
+          },
+          settings: {
+            displayName: 'CI Build',
+            buildDefinitionId: 987,
+          },
+        },
+        context: {
+          buildId: 456,
+          targetUrl:
+            'https://dev.azure.com/org/project/_build/results?buildId=456',
+          message: 'Build failed',
+        },
+      },
+    ];
+
+    const mockConnection: any = {
+      getGitApi: jest.fn().mockResolvedValue({
+        getPullRequestStatuses: jest.fn().mockResolvedValue(statusRecords),
+      }),
+      getPolicyApi: jest.fn().mockResolvedValue({
+        getPolicyEvaluations: jest.fn().mockResolvedValue(evaluationRecords),
+      }),
+    };
+
+    const result = await getPullRequestChecks(mockConnection, {
+      projectId: 'project',
+      repositoryId: 'repo',
+      pullRequestId: 42,
+    });
+
+    expect(result.statuses).toHaveLength(2);
+    expect(result.statuses[0].state).toBe('failed');
+    expect(result.statuses[0].pipeline?.pipelineId).toBe(55);
+    expect(result.statuses[0].pipeline?.runId).toBe(123);
+    expect(result.statuses[1].pipeline?.buildId).toBe(456);
+    expect(result.statuses[1].pipeline?.definitionId).toBe(789);
+
+    expect(result.policyEvaluations).toHaveLength(1);
+    expect(result.policyEvaluations[0].status).toBe('rejected');
+    expect(result.policyEvaluations[0].pipeline?.definitionId).toBe(987);
+    expect(result.policyEvaluations[0].pipeline?.buildId).toBe(456);
+    expect(result.policyEvaluations[0].targetUrl).toContain('buildId=456');
+  });
+
+  it('re-throws Azure DevOps errors', async () => {
+    const azureError = new AzureDevOpsError('Azure failure');
+    const mockConnection: any = {
+      getGitApi: jest.fn().mockRejectedValue(azureError),
+      getPolicyApi: jest.fn(),
+    };
+
+    await expect(
+      getPullRequestChecks(mockConnection, {
+        projectId: 'project',
+        repositoryId: 'repo',
+        pullRequestId: 1,
+      }),
+    ).rejects.toBe(azureError);
+  });
+
+  it('wraps unexpected errors', async () => {
+    const mockConnection: any = {
+      getGitApi: jest.fn().mockRejectedValue(new Error('boom')),
+      getPolicyApi: jest.fn(),
+    };
+
+    await expect(
+      getPullRequestChecks(mockConnection, {
+        projectId: 'project',
+        repositoryId: 'repo',
+        pullRequestId: 1,
+      }),
+    ).rejects.toThrow('Failed to get pull request checks: boom');
+  });
+});

--- a/src/features/pull-requests/get-pull-request-checks/feature.ts
+++ b/src/features/pull-requests/get-pull-request-checks/feature.ts
@@ -1,0 +1,397 @@
+import { WebApi } from 'azure-devops-node-api';
+import {
+  GitPullRequestStatus,
+  GitStatusState,
+} from 'azure-devops-node-api/interfaces/GitInterfaces';
+import {
+  PolicyEvaluationRecord,
+  PolicyEvaluationStatus,
+} from 'azure-devops-node-api/interfaces/PolicyInterfaces';
+import { AzureDevOpsError } from '../../../shared/errors';
+
+export interface PullRequestChecksOptions {
+  projectId: string;
+  repositoryId: string;
+  pullRequestId: number;
+}
+
+export interface PipelineReference {
+  pipelineId?: number;
+  definitionId?: number;
+  runId?: number;
+  buildId?: number;
+  displayName?: string;
+  targetUrl?: string;
+}
+
+export interface PullRequestStatusCheck {
+  id?: number;
+  state: string;
+  description?: string;
+  context?: {
+    name?: string;
+    genre?: string;
+  };
+  createdDate?: string;
+  updatedDate?: string;
+  targetUrl?: string;
+  pipeline?: PipelineReference;
+}
+
+export interface PullRequestPolicyCheck {
+  evaluationId?: string;
+  status: string;
+  isBlocking?: boolean;
+  isEnabled?: boolean;
+  configurationId?: number;
+  configurationRevision?: number;
+  configurationTypeId?: string;
+  configurationTypeDisplayName?: string;
+  displayName?: string;
+  startedDate?: string;
+  completedDate?: string;
+  message?: string;
+  targetUrl?: string;
+  pipeline?: PipelineReference;
+}
+
+export interface PullRequestChecksResult {
+  statuses: PullRequestStatusCheck[];
+  policyEvaluations: PullRequestPolicyCheck[];
+}
+
+/**
+ * Retrieve status checks and policy evaluations for a pull request.
+ */
+export async function getPullRequestChecks(
+  connection: WebApi,
+  options: PullRequestChecksOptions,
+): Promise<PullRequestChecksResult> {
+  try {
+    const gitApi = await connection.getGitApi();
+    const policyApi = await connection.getPolicyApi();
+
+    const [statusRecords, evaluationRecords] = await Promise.all([
+      gitApi.getPullRequestStatuses(
+        options.repositoryId,
+        options.pullRequestId,
+        options.projectId,
+      ),
+      policyApi.getPolicyEvaluations(
+        options.projectId,
+        buildPolicyArtifactId(options.projectId, options.pullRequestId),
+      ),
+    ]);
+
+    return {
+      statuses: (statusRecords ?? []).map(mapStatusRecord),
+      policyEvaluations: (evaluationRecords ?? []).map(mapEvaluationRecord),
+    };
+  } catch (error) {
+    if (error instanceof AzureDevOpsError) {
+      throw error;
+    }
+    throw new Error(
+      `Failed to get pull request checks: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
+
+const buildPolicyArtifactId = (projectId: string, pullRequestId: number) =>
+  `vstfs:///CodeReview/CodeReviewId/${projectId}/${pullRequestId}`;
+
+const gitStatusStateMap = GitStatusState as unknown as Record<number, string>;
+const policyStatusMap = PolicyEvaluationStatus as unknown as Record<
+  number,
+  string
+>;
+
+const mapStatusRecord = (
+  status: GitPullRequestStatus,
+): PullRequestStatusCheck => {
+  const pipeline = mergePipelineReferences(
+    parsePipelineReferenceFromUrl(status.targetUrl),
+    extractPipelineReferenceFromObject(status.context),
+    extractPipelineReferenceFromObject(status.properties),
+  );
+
+  return {
+    id: status.id,
+    state: formatEnumValue(status.state, gitStatusStateMap),
+    description: status.description,
+    context: {
+      name: status.context?.name,
+      genre: status.context?.genre,
+    },
+    createdDate: toIsoString(status.creationDate),
+    updatedDate: toIsoString(status.updatedDate),
+    targetUrl: status.targetUrl ?? pipeline?.targetUrl,
+    pipeline,
+  };
+};
+
+const mapEvaluationRecord = (
+  evaluation: PolicyEvaluationRecord,
+): PullRequestPolicyCheck => {
+  const settings =
+    (evaluation.configuration?.settings as Record<string, unknown>) || {};
+  const context =
+    (evaluation.context as Record<string, unknown> | undefined) ?? {};
+
+  const pipeline = mergePipelineReferences(
+    extractPipelineReferenceFromObject(settings),
+    extractPipelineReferenceFromObject(context),
+    parsePipelineReferenceFromUrl(
+      extractString(settings.targetUrl) ?? extractString(context.targetUrl),
+    ),
+  );
+
+  const displayName =
+    extractString(settings.displayName) ??
+    extractString(context.displayName) ??
+    evaluation.configuration?.type?.displayName;
+
+  const targetUrl =
+    pipeline?.targetUrl ??
+    extractString(context.targetUrl) ??
+    extractString(settings.targetUrl);
+
+  return {
+    evaluationId: evaluation.evaluationId,
+    status: formatEnumValue(evaluation.status, policyStatusMap),
+    isBlocking: evaluation.configuration?.isBlocking,
+    isEnabled: evaluation.configuration?.isEnabled,
+    configurationId: evaluation.configuration?.id,
+    configurationRevision: evaluation.configuration?.revision,
+    configurationTypeId: evaluation.configuration?.type?.id,
+    configurationTypeDisplayName: evaluation.configuration?.type?.displayName,
+    displayName,
+    startedDate: toIsoString(evaluation.startedDate),
+    completedDate: toIsoString(evaluation.completedDate),
+    message: extractString(context.message) ?? extractString(settings.message),
+    targetUrl,
+    pipeline,
+  };
+};
+
+const formatEnumValue = (
+  value: number | undefined,
+  map: Record<number, string>,
+): string => {
+  if (typeof value === 'number' && map[value]) {
+    const name = map[value];
+    return name.charAt(0).toLowerCase() + name.slice(1);
+  }
+  return 'unknown';
+};
+
+const toIsoString = (date: Date | undefined): string | undefined =>
+  date ? date.toISOString() : undefined;
+
+const extractString = (value: unknown): string | undefined =>
+  typeof value === 'string' ? value : undefined;
+
+const parseNumeric = (value: unknown): number | undefined => {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : undefined;
+};
+
+const parseIdFromUri = (uri?: string): number | undefined => {
+  if (!uri) {
+    return undefined;
+  }
+  const match = uri.match(/(\d+)(?!.*\d)/);
+  if (!match) {
+    return undefined;
+  }
+  const id = Number(match[1]);
+  return Number.isFinite(id) ? id : undefined;
+};
+
+const parsePipelineReferenceFromUrl = (
+  targetUrl?: string,
+): PipelineReference | undefined => {
+  if (!targetUrl) {
+    return undefined;
+  }
+
+  try {
+    const url = new URL(targetUrl);
+    const result: PipelineReference = { targetUrl };
+
+    const setParam = (param: string, setter: (value: number) => void) => {
+      const raw = url.searchParams.get(param);
+      const numeric = parseNumeric(raw);
+      if (numeric !== undefined) {
+        setter(numeric);
+      }
+    };
+
+    setParam('pipelineId', (value) => {
+      result.pipelineId = value;
+    });
+    setParam('definitionId', (value) => {
+      result.definitionId = value;
+    });
+    setParam('buildDefinitionId', (value) => {
+      result.definitionId = result.definitionId ?? value;
+    });
+    setParam('runId', (value) => {
+      result.runId = value;
+    });
+    setParam('buildId', (value) => {
+      result.buildId = value;
+      result.runId = result.runId ?? value;
+    });
+
+    const segments = url.pathname.split('/').filter(Boolean);
+
+    const pipelinesIndex = segments.lastIndexOf('pipelines');
+    if (pipelinesIndex !== -1 && pipelinesIndex + 1 < segments.length) {
+      const pipelineCandidate = parseNumeric(segments[pipelinesIndex + 1]);
+      if (pipelineCandidate !== undefined) {
+        result.pipelineId = result.pipelineId ?? pipelineCandidate;
+      }
+    }
+
+    const runsIndex = segments.lastIndexOf('runs');
+    if (runsIndex !== -1 && runsIndex + 1 < segments.length) {
+      const runCandidate = parseNumeric(segments[runsIndex + 1]);
+      if (runCandidate !== undefined) {
+        result.runId = result.runId ?? runCandidate;
+      }
+
+      if (runsIndex > 0) {
+        const preceding = segments[runsIndex - 1];
+        const pipelineCandidate = parseNumeric(preceding);
+        if (pipelineCandidate !== undefined) {
+          result.pipelineId = result.pipelineId ?? pipelineCandidate;
+        }
+      }
+    }
+
+    const buildMatch = url.pathname.match(/\/build\/(?:definition\/)?(\d+)/i);
+    if (!result.definitionId && buildMatch) {
+      const id = parseNumeric(buildMatch[1]);
+      if (id !== undefined) {
+        result.definitionId = id;
+      }
+    }
+
+    const buildUriMatch = url.pathname.match(/\/Build\/Build\/(\d+)/i);
+    if (buildUriMatch) {
+      const buildId = parseNumeric(buildUriMatch[1]);
+      if (buildId !== undefined) {
+        result.buildId = result.buildId ?? buildId;
+        result.runId = result.runId ?? buildId;
+      }
+    }
+
+    return result;
+  } catch {
+    return { targetUrl };
+  }
+};
+
+const extractPipelineReferenceFromObject = (
+  value: unknown,
+): PipelineReference | undefined => {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const object = value as Record<string, unknown>;
+  const candidate: PipelineReference = {};
+
+  const pipelineId = parseNumeric(
+    object.pipelineId ??
+      (object.pipeline as Record<string, unknown> | undefined)?.id,
+  );
+  if (pipelineId !== undefined) {
+    candidate.pipelineId = pipelineId;
+  }
+
+  const definitionId = parseNumeric(
+    object.definitionId ??
+      object.buildDefinitionId ??
+      object.pipelineDefinitionId ??
+      (object.definition as Record<string, unknown> | undefined)?.id,
+  );
+  if (definitionId !== undefined) {
+    candidate.definitionId = definitionId;
+  }
+
+  const runId = parseNumeric(
+    object.runId ??
+      object.buildId ??
+      object.stageRunId ??
+      object.jobRunId ??
+      object.planId,
+  );
+  if (runId !== undefined) {
+    candidate.runId = runId;
+  }
+
+  const buildId = parseNumeric(
+    object.buildId ??
+      (object.build as Record<string, unknown> | undefined)?.id ??
+      parseIdFromUri(extractString(object.buildUri)) ??
+      parseIdFromUri(extractString(object.uri)),
+  );
+  if (buildId !== undefined) {
+    candidate.buildId = candidate.buildId ?? buildId;
+    if (candidate.runId === undefined) {
+      candidate.runId = buildId;
+    }
+  }
+
+  const displayName =
+    extractString(object.displayName) ?? extractString(object.name);
+  if (displayName) {
+    candidate.displayName = displayName;
+  }
+
+  const targetUrl =
+    extractString(object.targetUrl) ??
+    extractString(object.url) ??
+    extractString(object.href);
+
+  return mergePipelineReferences(
+    candidate,
+    parsePipelineReferenceFromUrl(targetUrl),
+  );
+};
+
+const mergePipelineReferences = (
+  ...refs: Array<PipelineReference | undefined>
+): PipelineReference | undefined => {
+  const merged: PipelineReference = {};
+  let hasValue = false;
+
+  for (const ref of refs) {
+    if (!ref) {
+      continue;
+    }
+    const apply = <K extends keyof PipelineReference>(key: K) => {
+      const value = ref[key];
+      if (value !== undefined && merged[key] === undefined) {
+        merged[key] = value;
+        hasValue = true;
+      }
+    };
+
+    apply('pipelineId');
+    apply('definitionId');
+    apply('runId');
+    apply('buildId');
+    apply('displayName');
+    apply('targetUrl');
+  }
+
+  return hasValue ? merged : undefined;
+};

--- a/src/features/pull-requests/get-pull-request-checks/index.ts
+++ b/src/features/pull-requests/get-pull-request-checks/index.ts
@@ -1,0 +1,1 @@
+export * from './feature';

--- a/src/features/pull-requests/index.spec.unit.ts
+++ b/src/features/pull-requests/index.spec.unit.ts
@@ -7,6 +7,7 @@ import { getPullRequestComments } from './get-pull-request-comments';
 import { addPullRequestComment } from './add-pull-request-comment';
 import { AddPullRequestCommentSchema } from './schemas';
 import { getPullRequestChanges } from './get-pull-request-changes';
+import { getPullRequestChecks } from './get-pull-request-checks';
 
 // Mock the imported modules
 jest.mock('./create-pull-request', () => ({
@@ -29,6 +30,10 @@ jest.mock('./get-pull-request-changes', () => ({
   getPullRequestChanges: jest.fn(),
 }));
 
+jest.mock('./get-pull-request-checks', () => ({
+  getPullRequestChecks: jest.fn(),
+}));
+
 describe('Pull Requests Request Handlers', () => {
   const mockConnection = {} as WebApi;
 
@@ -40,6 +45,7 @@ describe('Pull Requests Request Handlers', () => {
         'get_pull_request_comments',
         'add_pull_request_comment',
         'get_pull_request_changes',
+        'get_pull_request_checks',
       ];
       validTools.forEach((tool) => {
         const request = {
@@ -241,6 +247,32 @@ describe('Pull Requests Request Handlers', () => {
         mockResult,
       );
       expect(getPullRequestChanges).toHaveBeenCalled();
+    });
+
+    it('should handle get_pull_request_checks request', async () => {
+      const mockResult = { statuses: [], policyEvaluations: [] };
+      (getPullRequestChecks as jest.Mock).mockResolvedValue(mockResult);
+
+      const request = {
+        params: {
+          name: 'get_pull_request_checks',
+          arguments: { repositoryId: 'test-repo', pullRequestId: 7 },
+        },
+        method: 'tools/call',
+      } as CallToolRequest;
+
+      const response = await handlePullRequestsRequest(mockConnection, request);
+
+      expect(JSON.parse(response.content[0].text as string)).toEqual(
+        mockResult,
+      );
+      expect(getPullRequestChecks).toHaveBeenCalledWith(
+        mockConnection,
+        expect.objectContaining({
+          repositoryId: 'test-repo',
+          pullRequestId: 7,
+        }),
+      );
     });
 
     it('should throw error for unknown tool', async () => {

--- a/src/features/pull-requests/index.ts
+++ b/src/features/pull-requests/index.ts
@@ -6,6 +6,7 @@ export * from './get-pull-request-comments';
 export * from './add-pull-request-comment';
 export * from './update-pull-request';
 export * from './get-pull-request-changes';
+export * from './get-pull-request-checks';
 
 // Export tool definitions
 export * from './tool-definitions';
@@ -25,12 +26,14 @@ import {
   AddPullRequestCommentSchema,
   UpdatePullRequestSchema,
   GetPullRequestChangesSchema,
+  GetPullRequestChecksSchema,
   createPullRequest,
   listPullRequests,
   getPullRequestComments,
   addPullRequestComment,
   updatePullRequest,
   getPullRequestChanges,
+  getPullRequestChecks,
 } from './';
 
 /**
@@ -47,6 +50,7 @@ export const isPullRequestsRequest: RequestIdentifier = (
     'add_pull_request_comment',
     'update_pull_request',
     'get_pull_request_changes',
+    'get_pull_request_checks',
   ].includes(toolName);
 };
 
@@ -155,6 +159,17 @@ export const handlePullRequestsRequest: RequestHandler = async (
         request.params.arguments,
       );
       const result = await getPullRequestChanges(connection, {
+        projectId: params.projectId ?? defaultProject,
+        repositoryId: params.repositoryId,
+        pullRequestId: params.pullRequestId,
+      });
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+    case 'get_pull_request_checks': {
+      const params = GetPullRequestChecksSchema.parse(request.params.arguments);
+      const result = await getPullRequestChecks(connection, {
         projectId: params.projectId ?? defaultProject,
         repositoryId: params.repositoryId,
         pullRequestId: params.pullRequestId,

--- a/src/features/pull-requests/schemas.ts
+++ b/src/features/pull-requests/schemas.ts
@@ -248,6 +248,22 @@ export const GetPullRequestChangesSchema = z.object({
   pullRequestId: z.number().describe('The ID of the pull request'),
 });
 
+/**
+ * Schema for retrieving pull request status checks and policy evaluations
+ */
+export const GetPullRequestChecksSchema = z.object({
+  projectId: z
+    .string()
+    .optional()
+    .describe(`The ID or name of the project (Default: ${defaultProject})`),
+  organizationId: z
+    .string()
+    .optional()
+    .describe(`The ID or name of the organization (Default: ${defaultOrg})`),
+  repositoryId: z.string().describe('The ID or name of the repository'),
+  pullRequestId: z.number().describe('The ID of the pull request'),
+});
+
 export const PullRequestFileChangeSchema = z.object({
   path: z.string().describe('Path of the changed file'),
   patch: z.string().describe('Unified diff of the file'),

--- a/src/features/pull-requests/tool-definitions.ts
+++ b/src/features/pull-requests/tool-definitions.ts
@@ -7,6 +7,7 @@ import {
   AddPullRequestCommentSchema,
   UpdatePullRequestSchema,
   GetPullRequestChangesSchema,
+  GetPullRequestChecksSchema,
 } from './schemas';
 
 /**
@@ -46,5 +47,14 @@ export const pullRequestsTools: ToolDefinition[] = [
     description:
       'Get the files changed in a pull request, their unified diffs, and the status of policy evaluations',
     inputSchema: zodToJsonSchema(GetPullRequestChangesSchema),
+  },
+  {
+    name: 'get_pull_request_checks',
+    description: [
+      'Summarize the latest status checks and policy evaluations for a pull request.',
+      '- Surfaces pipeline and run identifiers so you can jump straight to the blocking validation.',
+      '- Pair with pipeline tools (e.g., get_pipeline_run, pipeline_timeline) to inspect failures in depth.',
+    ].join('\n'),
+    inputSchema: zodToJsonSchema(GetPullRequestChecksSchema),
   },
 ];


### PR DESCRIPTION
## Summary\n- add get_pull_request_checks tool to surface PR status checks and related pipelines\n- wire schema, handler, docs, and version bump for release\n- expose guidance on linking pipeline tools to blocking validations\n\n## Testing\n- npm run build\n- npm run test:unit -- get-pull-request-checks\n