### PR TITLE
feat: - adding a pullRequestId filter in  - adding source and target …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hmaldonadovilla/mcp-server-azure-devops",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hmaldonadovilla/mcp-server-azure-devops",
-      "version": "0.1.53",
+    "version": "0.1.54",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmaldonadovilla/mcp-server-azure-devops",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "description": "Azure DevOps reference server for the Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/features/pull-requests/get-pull-request-changes/feature.spec.unit.ts
+++ b/src/features/pull-requests/get-pull-request-changes/feature.spec.unit.ts
@@ -4,30 +4,33 @@ import { Readable } from 'stream';
 
 describe('getPullRequestChanges unit', () => {
   test('should retrieve changes, evaluations, and patches', async () => {
-    const mockConnection: any = {
-      getGitApi: jest.fn().mockResolvedValue({
-        getPullRequestIterations: jest.fn().mockResolvedValue([{ id: 1 }]),
-        getPullRequestIterationChanges: jest.fn().mockResolvedValue({
-          changeEntries: [
-            {
-              item: {
-                path: '/file.txt',
-                objectId: 'new',
-                originalObjectId: 'old',
-              },
-            },
-          ],
-        }),
-        getBlobContent: jest
-          .fn()
-          .mockImplementation((_: string, sha: string) => {
-            const content = sha === 'new' ? 'new content\n' : 'old content\n';
-            const stream = new Readable();
-            stream.push(content);
-            stream.push(null);
-            return Promise.resolve(stream);
-          }),
+    const mockGitApi = {
+      getPullRequest: jest.fn().mockResolvedValue({
+        sourceRefName: 'refs/heads/feature',
+        targetRefName: 'refs/heads/main',
       }),
+      getPullRequestIterations: jest.fn().mockResolvedValue([{ id: 1 }]),
+      getPullRequestIterationChanges: jest.fn().mockResolvedValue({
+        changeEntries: [
+          {
+            item: {
+              path: '/file.txt',
+              objectId: 'new',
+              originalObjectId: 'old',
+            },
+          },
+        ],
+      }),
+      getBlobContent: jest.fn().mockImplementation((_: string, sha: string) => {
+        const content = sha === 'new' ? 'new content\n' : 'old content\n';
+        const stream = new Readable();
+        stream.push(content);
+        stream.push(null);
+        return Promise.resolve(stream);
+      }),
+    };
+    const mockConnection: any = {
+      getGitApi: jest.fn().mockResolvedValue(mockGitApi),
       getPolicyApi: jest.fn().mockResolvedValue({
         getPolicyEvaluations: jest.fn().mockResolvedValue([{ id: '1' }]),
       }),
@@ -51,11 +54,18 @@ describe('getPullRequestChanges unit', () => {
     expect(result.files[0].path).toBe('/file.txt');
     expect(result.files[0].patch).toContain('-old content');
     expect(result.files[0].patch).toContain('+new content');
+    expect(result.sourceRefName).toBe('refs/heads/feature');
+    expect(result.targetRefName).toBe('refs/heads/main');
+    expect(mockGitApi.getPullRequest).toHaveBeenCalledWith('r', 1, 'p');
   });
 
   test('should throw when no iterations found', async () => {
     const mockConnection: any = {
       getGitApi: jest.fn().mockResolvedValue({
+        getPullRequest: jest.fn().mockResolvedValue({
+          sourceRefName: 'refs/heads/source',
+          targetRefName: 'refs/heads/target',
+        }),
         getPullRequestIterations: jest.fn().mockResolvedValue([]),
       }),
     };

--- a/src/features/pull-requests/index.spec.unit.ts
+++ b/src/features/pull-requests/index.spec.unit.ts
@@ -135,6 +135,41 @@ describe('Pull Requests Request Handlers', () => {
         'test-repo',
         expect.objectContaining({
           status: 'active',
+          pullRequestId: undefined,
+        }),
+      );
+    });
+
+    it('should pass pullRequestId to list_pull_requests request', async () => {
+      const mockPullRequests = {
+        count: 1,
+        value: [{ id: 42, title: 'PR 42' }],
+        hasMoreResults: false,
+      };
+      (listPullRequests as jest.Mock).mockResolvedValue(mockPullRequests);
+
+      const request = {
+        params: {
+          name: 'list_pull_requests',
+          arguments: {
+            repositoryId: 'test-repo',
+            pullRequestId: 42,
+          },
+        },
+        method: 'tools/call',
+      } as CallToolRequest;
+
+      const response = await handlePullRequestsRequest(mockConnection, request);
+      expect(response.content).toHaveLength(1);
+      expect(JSON.parse(response.content[0].text as string)).toEqual(
+        mockPullRequests,
+      );
+      expect(listPullRequests).toHaveBeenCalledWith(
+        mockConnection,
+        expect.any(String),
+        'test-repo',
+        expect.objectContaining({
+          pullRequestId: 42,
         }),
       );
     });

--- a/src/features/pull-requests/index.ts
+++ b/src/features/pull-requests/index.ts
@@ -90,6 +90,7 @@ export const handlePullRequestsRequest: RequestHandler = async (
           targetRefName: params.targetRefName,
           top: params.top,
           skip: params.skip,
+          pullRequestId: params.pullRequestId,
         },
       );
       return {

--- a/src/features/pull-requests/list-pull-requests/feature.spec.int.ts
+++ b/src/features/pull-requests/list-pull-requests/feature.spec.int.ts
@@ -178,6 +178,25 @@ describe('listPullRequests integration', () => {
       expect(filteredPRs.value).toBeDefined();
       expect(Array.isArray(filteredPRs.value)).toBe(true);
       expect(filteredPRs.count).toBeGreaterThanOrEqual(0);
+
+      if (testPullRequest?.pullRequestId) {
+        const singlePR = await listPullRequests(
+          connection,
+          projectName,
+          repositoryName,
+          {
+            projectId: projectName,
+            repositoryId: repositoryName,
+            pullRequestId: testPullRequest.pullRequestId,
+          },
+        );
+
+        expect(singlePR.count).toBe(1);
+        expect(singlePR.value[0]?.pullRequestId).toBe(
+          testPullRequest.pullRequestId,
+        );
+        expect(singlePR.hasMoreResults).toBe(false);
+      }
     } catch (error) {
       console.error('Test error:', error);
       throw error;

--- a/src/features/pull-requests/list-pull-requests/feature.spec.unit.ts
+++ b/src/features/pull-requests/list-pull-requests/feature.spec.unit.ts
@@ -67,6 +67,50 @@ describe('listPullRequests', () => {
     );
   });
 
+  test('should return single pull request when pullRequestId is provided', async () => {
+    const mockPullRequest = {
+      pullRequestId: 42,
+      title: 'Specific PR',
+    };
+
+    const mockGitApi = {
+      getPullRequest: jest.fn().mockResolvedValue(mockPullRequest),
+      getPullRequests: jest.fn(),
+    };
+
+    const mockConnection: any = {
+      getGitApi: jest.fn().mockResolvedValue(mockGitApi),
+    };
+
+    const projectId = 'test-project';
+    const repositoryId = 'test-repo';
+    const options = {
+      projectId,
+      repositoryId,
+      pullRequestId: 42,
+    };
+
+    const result = await listPullRequests(
+      mockConnection as WebApi,
+      projectId,
+      repositoryId,
+      options,
+    );
+
+    expect(result).toEqual({
+      count: 1,
+      value: [mockPullRequest],
+      hasMoreResults: false,
+      warning: undefined,
+    });
+    expect(mockGitApi.getPullRequest).toHaveBeenCalledWith(
+      repositoryId,
+      42,
+      projectId,
+    );
+    expect(mockGitApi.getPullRequests).not.toHaveBeenCalled();
+  });
+
   test('should return empty array when no pull requests exist', async () => {
     // Setup mock connection
     const mockGitApi = {

--- a/src/features/pull-requests/list-pull-requests/feature.ts
+++ b/src/features/pull-requests/list-pull-requests/feature.ts
@@ -29,6 +29,22 @@ export async function listPullRequests(
   try {
     const gitApi = await connection.getGitApi();
 
+    if (options.pullRequestId !== undefined) {
+      const pullRequest = await gitApi.getPullRequest(
+        repositoryId,
+        options.pullRequestId,
+        projectId,
+      );
+
+      const value = pullRequest ? [pullRequest] : [];
+      return {
+        count: value.length,
+        value,
+        hasMoreResults: false,
+        warning: undefined,
+      };
+    }
+
     // Create search criteria
     const searchCriteria: GitPullRequestSearchCriteria = {};
 

--- a/src/features/pull-requests/schemas.ts
+++ b/src/features/pull-requests/schemas.ts
@@ -82,6 +82,10 @@ export const ListPullRequestsSchema = z.object({
     .number()
     .optional()
     .describe('Number of pull requests to skip for pagination'),
+  pullRequestId: z
+    .number()
+    .optional()
+    .describe('If provided, return only the matching pull request ID'),
 });
 
 /**
@@ -273,4 +277,6 @@ export const GetPullRequestChangesResponseSchema = z.object({
   changes: z.any(),
   evaluations: z.array(z.any()),
   files: z.array(PullRequestFileChangeSchema),
+  sourceRefName: z.string().optional(),
+  targetRefName: z.string().optional(),
 });

--- a/src/features/pull-requests/tool-definitions.ts
+++ b/src/features/pull-requests/tool-definitions.ts
@@ -45,7 +45,7 @@ export const pullRequestsTools: ToolDefinition[] = [
   {
     name: 'get_pull_request_changes',
     description:
-      'Get the files changed in a pull request, their unified diffs, and the status of policy evaluations',
+      'Get the files changed in a pull request, their unified diffs, source/target branch names, and the status of policy evaluations',
     inputSchema: zodToJsonSchema(GetPullRequestChangesSchema),
   },
   {

--- a/src/features/pull-requests/types.ts
+++ b/src/features/pull-requests/types.ts
@@ -65,6 +65,7 @@ export interface ListPullRequestsOptions {
   targetRefName?: string;
   top?: number;
   skip?: number;
+  pullRequestId?: number;
 }
 
 /**


### PR DESCRIPTION
feat:
  - adding a pullRequestId filter in list_pull_requests, to retrieve a single PR
  - adding source and target branch in the response of get_pull_request_changes

These changes are needed to:
  - allow agents to find a PR easily when repositories big amounts of them.
  - allow agents to have important information when picking up a PR that needs additional commits or updates.
